### PR TITLE
Update to jackson 2.7.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <netty.version>4.0.37.Final</netty.version>
+        <jackson.version>2.7.6</jackson.version>
         <slf4j.version>1.7.12</slf4j.version>
     </properties>
 
@@ -47,13 +48,13 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.6.3</version>
+            <version>${jackson.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jdk8</artifactId>
-            <version>2.6.3</version>
+            <version>${jackson.version}</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Update to jackson 2.7.6, the version of jackson that drop wizard uses
