### PR TITLE
Cleanup error message

### DIFF
--- a/src/main/java/com/bmc/truesight/saas/meter/client/rpc/TruesightRpcClient.java
+++ b/src/main/java/com/bmc/truesight/saas/meter/client/rpc/TruesightRpcClient.java
@@ -156,7 +156,7 @@ public class TruesightRpcClient implements TruesightMeterClient {
                 try {
                     this.connectSync();
                 } catch (Exception e) {
-                    LOGGER.error("Exception reconnecting");
+                    LOGGER.error("Exception reconnecting, make sure your TrueSight meter is running");
                 } finally {
                     connectionPending.set(false);
                 }


### PR DESCRIPTION
Make the error message for failing to connect to the TrueSight meter more explicit.

@gjesse 