### PR TITLE
Added a new Measure.of() which takes a 'Optional<String> source'. The…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.bmc.truesight.saas</groupId>
     <artifactId>meter-client</artifactId>
-    <version>0.13-SNAPSHOT</version>
+    <version>0.12-SNAPSHOT</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>A java library for interacting with the TrueSight Meter.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.bmc.truesight.saas</groupId>
     <artifactId>meter-client</artifactId>
-    <version>0.12-SNAPSHOT</version>
+    <version>0.13-SNAPSHOT</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>A java library for interacting with the TrueSight Meter.</description>
@@ -12,8 +12,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <netty.version>4.1.4.Final</netty.version>
-        <dw.version>1.0.5</dw.version>
+        <netty.version>4.1.16.Final</netty.version>
+        <dw.version>1.1.5</dw.version>
     </properties>
 
     <developers>
@@ -79,7 +79,7 @@
         <dependency>
             <groupId>org.immutables</groupId>
             <artifactId>value</artifactId>
-            <version>2.2.12</version>
+            <version>2.5.6</version>
             <scope>provided</scope>
         </dependency>
 
@@ -121,7 +121,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
+                <version>3.3</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>

--- a/src/main/java/com/bmc/truesight/saas/meter/client/model/Measure.java
+++ b/src/main/java/com/bmc/truesight/saas/meter/client/model/Measure.java
@@ -71,6 +71,14 @@ public abstract class Measure {
                 .build();
     }
 
+    public static Measure of(String name, double value, Optional<String> source) {
+        return ImmutableMeasure.builder()
+                               .name(name)
+                               .value(value)
+                               .source(source)
+                               .build();
+    }
+
     /**
      * Creates a Measure using the required parameters: name, value, timestamp and source.
      *
@@ -87,6 +95,15 @@ public abstract class Measure {
                 .timestamp(timestamp)
                 .source(source)
                 .build();
+    }
+
+    public static Measure of(String name, double value, Instant timestamp, Optional<String> source) {
+        return ImmutableMeasure.builder()
+                               .name(name)
+                               .value(value)
+                               .timestamp(timestamp)
+                               .source(source)
+                               .build();
     }
 
     @Value.Check

--- a/src/test/java/com/bmc/truesight/saas/meter/client/command/AddMeasuresTest.java
+++ b/src/test/java/com/bmc/truesight/saas/meter/client/command/AddMeasuresTest.java
@@ -26,6 +26,7 @@ public class AddMeasuresTest {
         System.out.println(data);
 
         validateMeasureString(m, data);
+        assertFalse(data.contains("s:Vulcan"));
     }
 
     @Test
@@ -47,7 +48,24 @@ public class AddMeasuresTest {
 
         validateMeasureString(m0, data.get(0));
         validateMeasureString(m1, data.get(1));
+        assertFalse(data.contains("s:Vulcan"));
+    }
 
+    @Test
+    public void testAddMeasuresWithSource() {
+
+        Measure m = ImmutableMeasure.builder()
+                                    .name("the-measure")
+                                    .value(44.2)
+                                    .source(Optional.of("Vulcan"))
+                                    .build();
+        AddMeasures am = AddMeasures.of(m);
+
+        String data = (String) am.getParams().get("data");
+        System.out.println(data);
+
+        validateMeasureString(m, data);
+        assertTrue(data.contains("s:Vulcan"));
     }
 
     private void validateOptionalMeasureString(Optional<String> optional, String id, String measureString) {


### PR DESCRIPTION
… existing Measure.of(name, value, source) does not work because the source must not have a null value, but source is an optional config item.